### PR TITLE
Add example of small-step reductions

### DIFF
--- a/LocalLang/Ctx.lean
+++ b/LocalLang/Ctx.lean
@@ -9,14 +9,14 @@ inductive Ctx : Type where
 
 abbrev Env := Std.HashMap String ℕ
 
-def Ctx.fill (e : Expr) : Ctx → Expr
+@[reducible] def Ctx.fill (e : Expr) : Ctx → Expr
   | hole => e
   | binOpLhs ctx op e' => Expr.binOp op (ctx.fill e) e'
   | binOpRhs n op ctx => Expr.binOp op (.const n) (ctx.fill e)
   | letInExpr x ctx e' => .letIn x (ctx.fill e) e'
   | letInBody x n ctx => .letIn x (.const n) (ctx.fill e)
 
-def Ctx.updateEnv (env : Env) : Ctx → Env
+@[reducible] def Ctx.updateEnv (env : Env) : Ctx → Env
   | hole => env
   | binOpLhs ctx _ _ => ctx.updateEnv env
   | binOpRhs _ _ ctx => ctx.updateEnv env

--- a/LocalLang/SemanticsExamples.lean
+++ b/LocalLang/SemanticsExamples.lean
@@ -1,7 +1,9 @@
 import LocalLang.Semantics
+import LocalLang.SemanticsLemmas
 import LocalLang.Ctx
 import Mathlib.Data.List.Sigma
 import Std.Data.HashMap.Basic
+import Std.Data.HashMap.Lemmas
 
 instance : Add Expr where
   add := .binOp .add
@@ -23,99 +25,65 @@ abbrev g : Function := {
 }
 
 abbrev defs := Std.HashMap.ofList [("f", f), ("g", g)]
-abbrev varsf := Std.HashMap.ofList [("x", 0)]
 
-/-
-lemma f_at_defs : defs["f"]? = some f := by
-  exact Std.HashMap.getElem?_ofList_of_mem (by rfl : "f" == "f") (by simp [defs_list])
-          (by simp)
-lemma g_at_defs : defs["g"]? = some g := by
-  simp [defs]
-  exact Std.HashMap.getElem?_ofList_of_mem (by rfl : "g" == "g") (by simp [defs_list])
-          (by simp [defs_list])
--/
+@[simp] lemma defs_f : defs["f"] = f := by
+  apply (Std.HashMap.getElem_ofList_of_mem (k := "f")) <;> simp
+@[simp] lemma defs_g : defs["g"] = g := by
+  apply (Std.HashMap.getElem_ofList_of_mem (k := "g")) <;> simp
 
-infixr:100 " ~> " => SmallStep defs _
-infixr:100 " ~~> " => SmallSteps defs _
-
-/-
-lemma step_in_body_implies_step_in_expr {body body' : Expr}
-  (st : SmallStep defs (.ofList [("x", 0)]) body body') :
-  .letIn "x" (.const 0) body ~> .letIn "x" (.const 0) body' := step_in_context_implies_step_in_expr
-    st (.letInBody "x" 0 .hole) (by simp [Ctx.updateEnv]) (by simp [Ctx.fill]) (by simp [Ctx.fill])
-    -/
-
-abbrev f_body₂ : Expr := .binOp .add
-  (.letIn "x" (.binOp .add (.var "x") (.const 1)) (.var "x"))
-  (.var "x")
-abbrev f_body₃ : Expr := .binOp .add
-  (.letIn "x" (.binOp .add (.const 0) (.const 1)) (.var "x"))
-  (.var "x")
-abbrev f_body₄ : Expr := .binOp .add
-  (.letIn "x" (.const 1) (.var "x"))
-  (.var "x")
-abbrev f_body₅ : Expr := .binOp .add
-  (.letIn "x" (.const 1) (.const 1))
-  (.var "x")
-abbrev f_body₆ : Expr := .binOp .add (.const 1) (.var "x")
-abbrev f_body₇ : Expr := .binOp .add (.const 1) (.const 0)
-abbrev f_body₈ : Expr := .const 1
-
-
-instance {defs : Definitions} :
-  Trans (SmallStep defs V) (SmallStep defs V) (SmallSteps defs V) where
-    trans st₁ st₂ := Relation.ReflTransGen.trans
-      (Relation.ReflTransGen.single st₁) (Relation.ReflTransGen.single st₂)
-
-@[simp] lemma defs_f : defs["f"] = f := sorry
-@[simp] lemma f_in_defs : "f" ∈ defs := sorry
+lemma f_steps
+  : SmallSteps defs (Std.HashMap.ofList [("x", 0)])
+      (Expr.funCall "g" ["x" + 1] + Expr.var "x") 1 := by
+  let locals := Std.HashMap.ofList [("x", 0)]
+  calc
+    SmallSteps defs locals _ (1 + "x") := by
+      apply (SmallSteps.with_ctx (.binOpLhs .hole .add "x") rfl rfl)
+      simp only [Ctx.updateEnv]
+      calc
+        SmallStep defs locals _ (.letIn "x" ("x" + 1) "x") := by
+          apply SmallStep.hole_step
+          apply (HeadSmallStep.fun_step ?_ rfl) <;> try rw [defs_g]
+          · simp
+          · rfl
+          · simp
+        SmallSteps defs locals _ (.letIn "x" 1 "x") := by
+          apply (SmallSteps.with_ctx (.letInExpr "x" .hole "x") rfl rfl)
+          calc
+            SmallStep defs locals _ ((0 : Expr) + 1) := by
+              apply (SmallStep.ctx_step (.binOpLhs .hole .add 1) rfl rfl)
+              constructor
+              simp [locals]
+            SmallStep defs locals _ _ := by
+              apply SmallStep.hole_step
+              constructor
+              rfl
+        SmallStep defs locals _ (.letIn "x" 1 1) := by
+          apply (SmallStep.ctx_step (.letInBody "x" 1 .hole) rfl rfl)
+          constructor
+          simp
+        SmallStep defs locals _ 1 := by
+          apply SmallStep.hole_step
+          constructor
+    SmallStep defs locals _ ((1 : Expr) + 0) := by
+      apply (SmallStep.ctx_step (.binOpRhs 1 .add .hole) rfl rfl)
+      constructor
+      simp [locals]
+    SmallStep defs locals _ _ := by
+      apply SmallStep.hole_step
+      constructor
+      rfl
 
 example : SmallSteps defs ∅ (.funCall "f" [0]) 1 := by
   calc
     SmallStep defs ∅ _ (.letIn "x" 0 f_body) := by
-      apply (SmallStep.ctx_step .hole rfl rfl)
+      apply SmallStep.hole_step
       apply (HeadSmallStep.fun_step ?_ rfl) <;> try rw [defs_f]
-      · simp [letin_chain]
+      · simp
       · rfl
       · simp
-
-
-
-
-/-
-    SmallStep defs ∅ _ (.letIn "x" (.const 0) f_body₂) := by
-      let body_step :=
-        @SmallStep.fun_step defs "g" (.ofList [("x", 0)]) ["x"] g.body
-          [.binOp .add (.var "x") (.const 1)]
-          (by apply Std.HashMap.mem_ofList.mpr; simp [defs_list])
-          (by simp)
-      simp [letin_chain] at body_step
-      rw [Std.HashMap.getElem_eq_get_getElem?] at body_step
-      simp [g_at_defs] at body_step
-      apply step_in_body_implies_step_in_expr
-      exact .ctx_step (.binOpLhs .hole .add (.var "x")) (.ofList [("x", 0)]) body_step
-    _ ~> .letIn "x" (.const 0) f_body₃ := step_in_body_implies_step_in_expr <|
-      .ctx_step (.binOpLhs
-          (.letInExpr "x" (.binOpLhs .hole .add (.const 1)) (.var "x"))
-          .add
-          (.var "x")
-        ) (.ofList [("x", 0)]) (.var_step (by simp [Ctx.updateEnv]))
-    _ ~> .letIn "x" (.const 0) f_body₄ := step_in_body_implies_step_in_expr <|
-        .ctx_step (.binOpLhs
-          (.letInExpr "x" .hole (.var "x"))
-          .add
-          (.var "x")
-        ) (.ofList [("x", 0)]) .bin_op_step
-    _ ~> .letIn "x" (.const 0) f_body₅ := step_in_context_implies_step_in_expr
-        (.var_step (by simp) :
-          SmallStep defs ((Std.HashMap.insert ∅ "x" 0).insert "x" 1) (.var "x") (.const 1))
-        (.letInBody "x" 0 (.binOpLhs (.letInBody "x" 1 .hole) .add (.var "x")))
-        (by simp [Ctx.updateEnv]) (by simp [Ctx.fill]) (by simp [Ctx.fill])
-    _ ~> .letIn "x" (.const 0) f_body₆ :=
-      .ctx_step (.letInBody "x" 0 (.binOpLhs .hole .add (.var "x"))) ∅ .letin_const_step
-    _ ~> .letIn "x" (.const 0) f_body₇ :=
-      .ctx_step (.letInBody "x" 0 (.binOpRhs 1 .add .hole)) ∅ (.var_step (by simp [Ctx.updateEnv]))
-    _ ~> .letIn "x" (.const 0) f_body₈ := .ctx_step (.letInBody "x" 0 .hole) ∅ .bin_op_step
-    _ ~> (.const 1) := .letin_const_step
-
--/
+    SmallSteps defs ∅ _ (.letIn "x" 0 1) := by
+      apply (SmallSteps.with_ctx (.letInBody "x" 0 .hole) rfl rfl)
+      exact f_steps
+    SmallStep defs ∅ _ _ := by
+      apply SmallStep.hole_step
+      constructor

--- a/LocalLang/SemanticsLemmas.lean
+++ b/LocalLang/SemanticsLemmas.lean
@@ -1,18 +1,21 @@
 import LocalLang.Semantics
 
-instance {defs : Definitions} :
+variable {defs : Definitions}
+
+instance :
   Trans (SmallStep defs V) (SmallStep defs V) (SmallSteps defs V) where
     trans st₁ st₂ := Relation.ReflTransGen.trans
       (Relation.ReflTransGen.single st₁) (Relation.ReflTransGen.single st₂)
 
-lemma head_step_implies_context_step {e₁ e₂ e₁' e₂' : Expr} {V V' : Env} {defs : Definitions}
-  (st : HeadSmallStep defs V' e₁ e₂) (ctx : Ctx) (HEnv : V' = ctx.updateEnv V)
-  (He₁ : e₁' = ctx.fill e₁) (He₂ : e₂' = ctx.fill e₂) : SmallStep defs V e₁' e₂' := by
-  rw [HEnv] at st
-  let result := SmallStep.ctx_step ctx V st
-  rw [← He₁, ← He₂] at result
-  assumption
+@[simp] lemma addBindings_single {e xe : Expr}
+    : e.addBindings [(x, xe)] = Expr.letIn x xe e := by sorry
 
-lemma steps_in_context_imply_steps_in_expr {e₁ e₂ e₁' e₂' : Expr} {V V' : Env} {defs : Definitions}
-  (sts : SmallSteps defs V' e₁ e₂) (ctx : Ctx) (HEnv : V' = ctx.updateEnv V)
-  (He₁ : e₁' = ctx.fill e₁) (He₂ : e₂' = ctx.fill e₂) : SmallSteps defs V e₁' e₂' := by sorry
+lemma SmallStep.hole_step : HeadSmallStep defs V e₁ e₂ → SmallStep defs V e₁ e₂ := by sorry
+
+lemma SmallStep.with_ctx (ctx : Ctx)
+    : (e₁' = ctx.fill e₁) → (e₂' = ctx.fill e₂)
+    → SmallStep defs (ctx.updateEnv V) e₁ e₂ → SmallStep defs V e₁' e₂' := by sorry
+
+lemma SmallSteps.with_ctx (ctx : Ctx)
+    : (e₁' = ctx.fill e₁) → (e₂' = ctx.fill e₂)
+    → SmallSteps defs (ctx.updateEnv V) e₁ e₂ → SmallSteps defs V e₁' e₂' := by sorry


### PR DESCRIPTION
Based on Iva's work on the same.

Also rename letin_chain to withBindings, since it's clearer that way.

Made the naming of lemmas somewhat more uniform (though we should really find a resource on that).